### PR TITLE
Add resource limits and requests for Redis master

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,9 @@ jobs:
       - name: ⚙️ Install KSail
         run: brew install devantler/formulas/ksail
       - name: ⛴️ Provision cluster
-        run: ksail up ${{ vars.KSAIL_CLUSTER_NAME }} --timeout 400
+        run: |
+          ksail sops ${{ vars.KSAIL_CLUSTER_NAME }} --import "${{ secrets.KSAIL_SOPS_KEY }}"
+          ksail up ${{ vars.KSAIL_CLUSTER_NAME }} --timeout 400
         env:
           KSAIL_SOPS_KEY: ${{ secrets.KSAIL_SOPS_KEY }}
       - name: 🐎 Print free CPU

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: ⛴️ Provision cluster
         run: |
           ksail sops ${{ vars.KSAIL_CLUSTER_NAME }} --import "${{ secrets.KSAIL_SOPS_KEY }}"
-          ksail up ${{ vars.KSAIL_CLUSTER_NAME }} --timeout 400
+          ksail up ${{ vars.KSAIL_CLUSTER_NAME }} --timeout 500
         env:
           KSAIL_SOPS_KEY: ${{ secrets.KSAIL_SOPS_KEY }}
       - name: 🐎 Print free CPU

--- a/k8s/redis/release.yaml
+++ b/k8s/redis/release.yaml
@@ -22,6 +22,13 @@ spec:
     master:
       persistence:
         enabled: ${redis_persistence_enabled:=false}
+      resources:
+        requests:
+          cpu: ${redis_master_cpu_request:=100m}
+          memory: ${redis_master_memory_request:=128Mi}
+        limits:
+          cpu: ${redis_master_cpu_limit:=200m}
+          memory: ${redis_master_memory_limit:=256Mi}
     replica:
       persistence:
         enabled: ${redis_persistence_enabled:=false}

--- a/k8s/redis/release.yaml
+++ b/k8s/redis/release.yaml
@@ -24,10 +24,10 @@ spec:
         enabled: ${redis_persistence_enabled:=false}
       resources:
         requests:
-          cpu: ${redis_master_cpu_request:=100m}
+          cpu: ${redis_master_cpu_request:=50m}
           memory: ${redis_master_memory_request:=128Mi}
         limits:
-          cpu: ${redis_master_cpu_limit:=200m}
+          cpu: ${redis_master_cpu_limit:=100m}
           memory: ${redis_master_memory_limit:=256Mi}
     replica:
       persistence:


### PR DESCRIPTION
I believe this should make sure that pod eviction is handled better. Prior to this, Redis had no limits, and thus Kubernetes has trouble scheduling it properly. 
If this does not work, we might have to scale our node pool, as AKS has a default behavior to evict pods when it runs low on resources which is why this is happening.

Anyhow this will atleast let us track how much memory Redis is consuming out of its limits, so it can give us a better idea on what is going on.