### PR TITLE
Add CPU and memory limits to Testkube

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: ⛴️ Provision cluster
         run: |
           ksail sops ${{ vars.KSAIL_CLUSTER_NAME }} --import "${{ secrets.KSAIL_SOPS_KEY }}"
-          ksail up ${{ vars.KSAIL_CLUSTER_NAME }} --timeout 500
+          ksail up ${{ vars.KSAIL_CLUSTER_NAME }} --timeout 600
         env:
           KSAIL_SOPS_KEY: ${{ secrets.KSAIL_SOPS_KEY }}
       - name: 🐎 Print free CPU

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: ⛴️ Provision cluster
         run: |
           ksail sops ${{ vars.KSAIL_CLUSTER_NAME }} --import "${{ secrets.KSAIL_SOPS_KEY }}"
-          ksail up ${{ vars.KSAIL_CLUSTER_NAME }} --timeout 600
+          ksail up ${{ vars.KSAIL_CLUSTER_NAME }} --timeout 400
         env:
           KSAIL_SOPS_KEY: ${{ secrets.KSAIL_SOPS_KEY }}
       - name: 🐎 Print free CPU

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: ⛴️ Provision cluster
         run: |
           ksail sops ${{ vars.KSAIL_CLUSTER_NAME }} --import "${{ secrets.KSAIL_SOPS_KEY }}"
-          ksail up ${{ vars.KSAIL_CLUSTER_NAME }} --timeout 400
+          ksail up ${{ vars.KSAIL_CLUSTER_NAME }} --timeout 500
         env:
           KSAIL_SOPS_KEY: ${{ secrets.KSAIL_SOPS_KEY }}
       - name: 🐎 Print free CPU

--- a/k8s/redis/README.md
+++ b/k8s/redis/README.md
@@ -7,12 +7,14 @@ Redis is a key-value store that can be used as a database, cache, or message bro
 
 ## Post-build variables
 
-| Variable                    | Description                                 | Default | Required |
-| --------------------------- | ------------------------------------------- | :-----: | :------: |
-| redis_password              | The password for the Redis instance         |         |    ✓     |
-| redis_persistence_enabled   | Whether to enable persistence               |  false  |    ✕     |
-| redis_replica_count         | The number of replicas                      |    1    |    ✕     |
-| redis_master_cpu_request    | The CPU request for the redis master pdo    |   50m   |    ✕     |
-| redis_master_memory_request | The memory request for the redis master pod |  128Mi  |    ✕     |
-| redis_master_cpu_limit      | The CPU limit for the redis master pod      |  100m   |    ✕     |
-| redis_master_memory_limit   | The memory limit for the redis master pod   |  256Mi  |    ✕     |
+| Variable                         | Description                                 | Default | Required |
+| -------------------------------- | ------------------------------------------- | :-----: | :------: |
+| **Configuration**                |                                             |         |          |
+| redis_password                   | The password for the Redis instance         |         |    ✓     |
+| redis_persistence_enabled        | Whether to enable persistence               |  false  |    ✕     |
+| redis_replica_count              | The number of replicas                      |    1    |    ✕     |
+| **Resource Requests and Limits** |                                             |         |          |
+| redis_master_cpu_request         | The CPU request for the redis master pdo    |   50m   |    ✕     |
+| redis_master_memory_request      | The memory request for the redis master pod |  128Mi  |    ✕     |
+| redis_master_cpu_limit           | The CPU limit for the redis master pod      |  100m   |    ✕     |
+| redis_master_memory_limit        | The memory limit for the redis master pod   |  256Mi  |    ✕     |

--- a/k8s/redis/release.yaml
+++ b/k8s/redis/release.yaml
@@ -25,10 +25,10 @@ spec:
       resources:
         requests:
           cpu: ${redis_master_cpu_request:=50m}
-          memory: ${redis_master_memory_request:=128Mi}
+          memory: ${redis_master_memory_request:=100Mi}
         limits:
           cpu: ${redis_master_cpu_limit:=100m}
-          memory: ${redis_master_memory_limit:=256Mi}
+          memory: ${redis_master_memory_limit:=200Mi}
     replica:
       persistence:
         enabled: ${redis_persistence_enabled:=false}

--- a/k8s/testkube/README.md
+++ b/k8s/testkube/README.md
@@ -12,7 +12,7 @@ TestKube is a service that allows you to run tests on your Kubernetes cluster.
 | `testkube_minio_cpu_request`        | Minio CPU request        |  `50m`  |    ✕     |
 | `testkube_minio_memory_request`     | Minio memory request     | `50Mi`  |    ✕     |
 | `testkube_minio_cpu_limit`          | Minio CPU limit          |  `100m`  |    ✕     |
-| `testkube_minio_memory_limit`       | Minio memory limit       | `100Mi`  |    ✕     |
+| `testkube_minio_memory_limit`       | Minio memory limit       | `150Mi`  |    ✕     |
 | `testkube_mongodb_cpu_request`      | MongoDB CPU request      | `150m`  |    ✕     |
 | `testkube_mongodb_memory_request`   | MongoDB memory request   | `100Mi` |    ✕     |
 | `testkube_mongodb_cpu_limit`        | MongoDB CPU limit        | `150m`  |    ✕     |

--- a/k8s/testkube/README.md
+++ b/k8s/testkube/README.md
@@ -17,7 +17,6 @@ TestKube is a service that allows you to run tests on your Kubernetes cluster.
 | testkube_minio_memory_limit            | Minio memory limit            | `150Mi` |    ✕     |
 | testkube_mongodb_cpu_request           | MongoDB CPU request           | `150m`  |    ✕     |
 | testkube_mongodb_memory_request        | MongoDB memory request        | `100Mi` |    ✕     |
-| testkube_mongodb_cpu_limit             | MongoDB CPU limit             | `300m`  |    ✕     |
 | testkube_api_cpu_request               | API CPU request               | `200m`  |    ✕     |
 | testkube_api_memory_request            | API memory request            | `200Mi` |    ✕     |
 | testkube_api_cpu_limit                 | API CPU limit                 | `200m`  |    ✕     |

--- a/k8s/testkube/README.md
+++ b/k8s/testkube/README.md
@@ -4,3 +4,24 @@ TestKube is a service that allows you to run tests on your Kubernetes cluster.
 
 - [Documentation](https://docs.testkube.io)
 - [Helm Chart](https://github.com/kubeshop/helm-charts/tree/develop/charts/testkube)
+
+## Post-build variables
+
+| Variable                            | Description              | Default | Required |
+| ----------------------------------- | ------------------------ | :-----: | :------: |
+| `testkube_minio_cpu_request`        | Minio CPU request        |  `25m`  |    ✕     |
+| `testkube_minio_memory_request`     | Minio memory request     | `25Mi`  |    ✕     |
+| `testkube_minio_cpu_limit`          | Minio CPU limit          |  `50m`  |    ✕     |
+| `testkube_minio_memory_limit`       | Minio memory limit       | `50Mi`  |    ✕     |
+| `testkube_mongodb_cpu_request`      | MongoDB CPU request      | `150m`  |    ✕     |
+| `testkube_mongodb_memory_request`   | MongoDB memory request   | `100Mi` |    ✕     |
+| `testkube_mongodb_cpu_limit`        | MongoDB CPU limit        | `150m`  |    ✕     |
+| `testkube_mongodb_memory_limit`     | MongoDB memory limit     | `100Mi` |    ✕     |
+| `testkube_api_cpu_request`          | API CPU request          | `200m`  |    ✕     |
+| `testkube_api_memory_request`       | API memory request       | `200Mi` |    ✕     |
+| `testkube_api_cpu_limit`            | API CPU limit            | `200m`  |    ✕     |
+| `testkube_api_memory_limit`         | API memory limit         | `200Mi` |    ✕     |
+| `testkube_dashboard_cpu_request`    | Dashboard CPU request    |  `25m`  |    ✕     |
+| `testkube_dashboard_memory_request` | Dashboard memory request | `25Mi`  |    ✕     |
+| `testkube_dashboard_cpu_limit`      | Dashboard CPU limit      |  `50m`  |    ✕     |
+| `testkube_dashboard_memory_limit`   | Dashboard memory limit   | `50Mi`  |    ✕     |

--- a/k8s/testkube/README.md
+++ b/k8s/testkube/README.md
@@ -17,8 +17,8 @@ TestKube is a service that allows you to run tests on your Kubernetes cluster.
 | testkube_minio_memory_limit            | Minio memory limit            | `150Mi` |    ✕     |
 | testkube_mongodb_cpu_request           | MongoDB CPU request           | `150m`  |    ✕     |
 | testkube_mongodb_memory_request        | MongoDB memory request        | `100Mi` |    ✕     |
-| testkube_api_cpu_request               | API CPU request               | `200m`  |    ✕     |
-| testkube_api_memory_request            | API memory request            | `200Mi` |    ✕     |
+| testkube_api_cpu_request               | API CPU request               | `100m`  |    ✕     |
+| testkube_api_memory_request            | API memory request            | `100Mi` |    ✕     |
 | testkube_api_cpu_limit                 | API CPU limit                 | `200m`  |    ✕     |
 | testkube_api_memory_limit              | API memory limit              | `200Mi` |    ✕     |
 | testkube_dashboard_cpu_request         | Dashboard CPU request         |  `25m`  |    ✕     |

--- a/k8s/testkube/README.md
+++ b/k8s/testkube/README.md
@@ -9,10 +9,10 @@ TestKube is a service that allows you to run tests on your Kubernetes cluster.
 
 | Variable                            | Description              | Default | Required |
 | ----------------------------------- | ------------------------ | :-----: | :------: |
-| `testkube_minio_cpu_request`        | Minio CPU request        |  `25m`  |    ✕     |
-| `testkube_minio_memory_request`     | Minio memory request     | `25Mi`  |    ✕     |
-| `testkube_minio_cpu_limit`          | Minio CPU limit          |  `50m`  |    ✕     |
-| `testkube_minio_memory_limit`       | Minio memory limit       | `50Mi`  |    ✕     |
+| `testkube_minio_cpu_request`        | Minio CPU request        |  `50m`  |    ✕     |
+| `testkube_minio_memory_request`     | Minio memory request     | `50Mi`  |    ✕     |
+| `testkube_minio_cpu_limit`          | Minio CPU limit          |  `100m`  |    ✕     |
+| `testkube_minio_memory_limit`       | Minio memory limit       | `100Mi`  |    ✕     |
 | `testkube_mongodb_cpu_request`      | MongoDB CPU request      | `150m`  |    ✕     |
 | `testkube_mongodb_memory_request`   | MongoDB memory request   | `100Mi` |    ✕     |
 | `testkube_mongodb_cpu_limit`        | MongoDB CPU limit        | `150m`  |    ✕     |

--- a/k8s/testkube/README.md
+++ b/k8s/testkube/README.md
@@ -7,21 +7,29 @@ TestKube is a service that allows you to run tests on your Kubernetes cluster.
 
 ## Post-build variables
 
-| Variable                            | Description              | Default | Required |
-| ----------------------------------- | ------------------------ | :-----: | :------: |
-| `testkube_minio_cpu_request`        | Minio CPU request        |  `50m`  |    ✕     |
-| `testkube_minio_memory_request`     | Minio memory request     | `50Mi`  |    ✕     |
-| `testkube_minio_cpu_limit`          | Minio CPU limit          |  `100m`  |    ✕     |
-| `testkube_minio_memory_limit`       | Minio memory limit       | `150Mi`  |    ✕     |
-| `testkube_mongodb_cpu_request`      | MongoDB CPU request      | `150m`  |    ✕     |
-| `testkube_mongodb_memory_request`   | MongoDB memory request   | `100Mi` |    ✕     |
-| `testkube_mongodb_cpu_limit`        | MongoDB CPU limit        | `150m`  |    ✕     |
-| `testkube_mongodb_memory_limit`     | MongoDB memory limit     | `100Mi` |    ✕     |
-| `testkube_api_cpu_request`          | API CPU request          | `200m`  |    ✕     |
-| `testkube_api_memory_request`       | API memory request       | `200Mi` |    ✕     |
-| `testkube_api_cpu_limit`            | API CPU limit            | `200m`  |    ✕     |
-| `testkube_api_memory_limit`         | API memory limit         | `200Mi` |    ✕     |
-| `testkube_dashboard_cpu_request`    | Dashboard CPU request    |  `25m`  |    ✕     |
-| `testkube_dashboard_memory_request` | Dashboard memory request | `25Mi`  |    ✕     |
-| `testkube_dashboard_cpu_limit`      | Dashboard CPU limit      |  `50m`  |    ✕     |
-| `testkube_dashboard_memory_limit`   | Dashboard memory limit   | `50Mi`  |    ✕     |
+| Variable                               | Description                   | Default | Required |
+| -------------------------------------- | ----------------------------- | :-----: | :------: |
+| **Configuration**                      |                               |         |          |
+| **Resource Resquests and Limits**      |                               |         |          |
+| testkube_minio_cpu_request             | Minio CPU request             |  `50m`  |    ✕     |
+| testkube_minio_memory_request          | Minio memory request          | `50Mi`  |    ✕     |
+| testkube_minio_cpu_limit               | Minio CPU limit               | `100m`  |    ✕     |
+| testkube_minio_memory_limit            | Minio memory limit            | `150Mi` |    ✕     |
+| testkube_mongodb_cpu_request           | MongoDB CPU request           | `150m`  |    ✕     |
+| testkube_mongodb_memory_request        | MongoDB memory request        | `100Mi` |    ✕     |
+| testkube_mongodb_cpu_limit             | MongoDB CPU limit             | `300m`  |    ✕     |
+| testkube_api_cpu_request               | API CPU request               | `200m`  |    ✕     |
+| testkube_api_memory_request            | API memory request            | `200Mi` |    ✕     |
+| testkube_api_cpu_limit                 | API CPU limit                 | `200m`  |    ✕     |
+| testkube_api_memory_limit              | API memory limit              | `200Mi` |    ✕     |
+| testkube_dashboard_cpu_request         | Dashboard CPU request         |  `25m`  |    ✕     |
+| testkube_dashboard_memory_request      | Dashboard memory request      | `25Mi`  |    ✕     |
+| testkube_dashboard_cpu_limit           | Dashboard CPU limit           |  `50m`  |    ✕     |
+| testkube_dashboard_memory_limit        | Dashboard memory limit        | `50Mi`  |    ✕     |
+| testkube_operator_cpu_request          | Operator CPU request          |  `25m`  |    ✕     |
+| testkube_operator_memory_request       | Operator memory request       | `25Mi`  |    ✕     |
+| testkube_operator_cpu_limit            | Operator CPU limit            |  `50m`  |    ✕     |
+| testkube_operator_memory_limit         | Operator memory limit         | `50Mi`  |    ✕     |
+| testkube_operator_proxy_cpu_request    | Operator Proxy CPU request    |  `25m`  |    ✕     |
+| testkube_operator_proxy_memory_request | Operator Proxy memory request | `25Mi`  |    ✕     |
+| testkube_operator_proxy_cpu_limit      | Operator Proxy CPU limit      |  `50m`  |    ✕     |

--- a/k8s/testkube/release.yaml
+++ b/k8s/testkube/release.yaml
@@ -33,8 +33,8 @@ spec:
             memory: ${testkube_minio_memory_limit:=150Mi}
       resources:
         requests:
-          cpu: ${testkube_api_cpu_request:=200m}
-          memory: ${testkube_api_memory_request:=200Mi}
+          cpu: ${testkube_api_cpu_request:=100m}
+          memory: ${testkube_api_memory_request:=100Mi}
         limits:
           cpu: ${testkube_api_cpu_limit:=200m}
           memory: ${testkube_api_memory_limit:=200Mi}

--- a/k8s/testkube/release.yaml
+++ b/k8s/testkube/release.yaml
@@ -23,9 +23,40 @@ spec:
         hosts:
           - testkube.${cluster_domain}
         path: /v1 # This is required for the ingress to work per https://github.com/kubeshop/helm-charts/issues/428#issuecomment-1873973628
+      minio:
+        resources:
+          requests:
+            cpu: ${testkube_minio_cpu_request:=25m}
+            memory: ${testkube_minio_memory_request:=25Mi}
+          limits:
+            cpu: ${testkube_minio_cpu_limit:=50m}
+            memory: ${testkube_minio_memory_limit:=50Mi}
+      mongodb:
+        resources:
+          requests:
+            cpu: ${testkube_mongodb_cpu_request:=150m}
+            memory: ${testkube_mongodb_memory_request:=100Mi}
+          limits:
+            cpu: ${testkube_mongodb_cpu_limit:=150m}
+            memory: ${testkube_mongodb_memory_limit:=100Mi}
+      resources:
+        requests:
+          cpu: ${testkube_api_cpu_request:=200m}
+          memory: ${testkube_api_memory_request:=200Mi}
+        limits:
+          cpu: ${testkube_api_cpu_limit:=200m}
+          memory: ${testkube_api_memory_limit:=200Mi}
     testkube-dashboard:
       ingress:
         enabled: true
         hosts:
           - testkube.${cluster_domain}
       apiServerEndpoint: testkube.${cluster_domain}${cluster_ingress_port:=}
+      resources:
+        requests:
+          cpu: ${testkube_dashboard_cpu_request:=25m}
+          memory: ${testkube_dashboard_memory_request:=25Mi}
+        limits:
+          cpu: ${testkube_dashboard_cpu_limit:=50m}
+          memory: ${testkube_dashboard_memory_limit:=50Mi}
+

--- a/k8s/testkube/release.yaml
+++ b/k8s/testkube/release.yaml
@@ -31,14 +31,6 @@ spec:
           limits:
             cpu: ${testkube_minio_cpu_limit:=100m}
             memory: ${testkube_minio_memory_limit:=150Mi}
-      mongodb:
-        resources:
-          requests:
-            cpu: ${testkube_mongodb_cpu_request:=150m}
-            memory: ${testkube_mongodb_memory_request:=100Mi}
-          limits:
-            cpu: ${testkube_mongodb_cpu_limit:=150m}
-            memory: ${testkube_mongodb_memory_limit:=100Mi}
       resources:
         requests:
           cpu: ${testkube_api_cpu_request:=200m}
@@ -59,4 +51,26 @@ spec:
         limits:
           cpu: ${testkube_dashboard_cpu_limit:=50m}
           memory: ${testkube_dashboard_memory_limit:=50Mi}
-
+    testkube-operator:
+      proxy:
+        resources:
+          requests:
+            cpu: ${testkube_operator_proxy_cpu_request:=25m}
+            memory: ${testkube_operator_proxy_memory_request:=25Mi}
+          limits:
+            cpu: ${testkube_operator_proxy_cpu_limit:=50m}
+            memory: ${testkube_operator_proxy_memory_limit:=50Mi}
+      resources:
+        requests:
+          cpu: ${testkube_operator_cpu_request:=50m}
+          memory: ${testkube_operator_memory_request:=50Mi}
+        limits:
+          cpu: ${testkube_operator_cpu_limit:=100m}
+          memory: ${testkube_operator_memory_limit:=100Mi}
+    mongodb:
+      resources:
+        requests:
+          cpu: ${testkube_mongodb_cpu_request:=150m}
+          memory: ${testkube_mongodb_memory_request:=100Mi}
+        limits:
+          cpu: ${testkube_mongodb_cpu_limit:=1}

--- a/k8s/testkube/release.yaml
+++ b/k8s/testkube/release.yaml
@@ -30,7 +30,7 @@ spec:
             memory: ${testkube_minio_memory_request:=50Mi}
           limits:
             cpu: ${testkube_minio_cpu_limit:=100m}
-            memory: ${testkube_minio_memory_limit:=100Mi}
+            memory: ${testkube_minio_memory_limit:=150Mi}
       mongodb:
         resources:
           requests:

--- a/k8s/testkube/release.yaml
+++ b/k8s/testkube/release.yaml
@@ -26,11 +26,11 @@ spec:
       minio:
         resources:
           requests:
-            cpu: ${testkube_minio_cpu_request:=25m}
-            memory: ${testkube_minio_memory_request:=25Mi}
+            cpu: ${testkube_minio_cpu_request:=50m}
+            memory: ${testkube_minio_memory_request:=50Mi}
           limits:
-            cpu: ${testkube_minio_cpu_limit:=50m}
-            memory: ${testkube_minio_memory_limit:=50Mi}
+            cpu: ${testkube_minio_cpu_limit:=100m}
+            memory: ${testkube_minio_memory_limit:=100Mi}
       mongodb:
         resources:
           requests:

--- a/k8s/testkube/release.yaml
+++ b/k8s/testkube/release.yaml
@@ -72,5 +72,3 @@ spec:
         requests:
           cpu: ${testkube_mongodb_cpu_request:=150m}
           memory: ${testkube_mongodb_memory_request:=100Mi}
-        limits:
-          cpu: ${testkube_mongodb_cpu_limit:=1}


### PR DESCRIPTION
Fixes #23

Depends on the substation data cluster to be spun up, so we can run the GHA runner on its infrastructure.