### PR TITLE
Update post-build variables in README files

### DIFF
--- a/k8s/gha-runner-scale-set/README.md
+++ b/k8s/gha-runner-scale-set/README.md
@@ -5,3 +5,12 @@ GitHub Runner Scale Set enables running self-hosted GitHub Actions runners in Ku
 ## Dependencies
 
 - [GitHub Runner Scale Set Controller](../gha-runner-scale-set-controller/README.md)
+
+## Post-build variables
+
+| Variable              | Description                                                                        | Default | Required |
+| --------------------- | ---------------------------------------------------------------------------------- | :-----: | :------: |
+| actions_runner_image  | The image to use for the GitHub Actions Runner Scale set.                          |   ""    |    ✓     |
+| github_config_url     | The URL to the GitHub org or repo to scope the GitHub Actions Runner Scale set to. |   ""    |    ✓     |
+| github_token          | The GitHub Token required to authenticate with your GitHub org or repo.            |   ""    |    ✓     |
+| runner_scale_set_name | The name of the GitHub Actions Runner Scale set.                                   |   ""    |    ✓     |

--- a/k8s/harbor/README.md
+++ b/k8s/harbor/README.md
@@ -13,7 +13,7 @@ Harbor is an open-source cloud native registry that stores, signs, and scans con
 
 ## Post-build variables
 
-| Variable             | Description                     | Default | Required |
-| -------------------- | ------------------------------- | :-----: | :------: |
-| cluster_domain       | The domain of the cluster       |         |    ✓     |
-| cluster_ingress_port | The port of the cluster ingress |   ""    |    ✕     |
+| Variable             | Description               | Default | Required |
+| -------------------- | ------------------------- | :-----: | :------: |
+| cluster_domain       | The domain of the cluster |   ""    |    ✓     |
+| cluster_ingress_port | The port of the ingress   |   ""    |    ✕     |

--- a/k8s/redis/README.md
+++ b/k8s/redis/README.md
@@ -7,12 +7,8 @@ Redis is a key-value store that can be used as a database, cache, or message bro
 
 ## Post-build variables
 
-| Variable                    | Description                                 | Default | Required |
-| --------------------------- | ------------------------------------------- | :-----: | :------: |
-| redis_password              | The password for the Redis instance         |         |    ✓     |
-| redis_persistence_enabled   | Whether to enable persistence               |  false  |    ✕     |
-| redis_replica_count         | The number of replicas                      |    1    |    ✕     |
-| redis_master_cpu_request    | The CPU request for the redis master pdo    |   50m   |    ✕     |
-| redis_master_memory_request | The memory request for the redis master pod |  128Mi  |    ✕     |
-| redis_master_cpu_limit      | The CPU limit for the redis master pod      |  100m   |    ✕     |
-| redis_master_memory_limit   | The memory limit for the redis master pod   |  256Mi  |    ✕     |
+| Variable                  | Description                         | Default | Required |
+| ------------------------- | ----------------------------------- | :-----: | :------: |
+| redis_password            | The password for the Redis instance | "redis" |    ✕     |
+| redis_persistence_enabled | Whether to enable persistence       |  false  |    ✕     |
+| redis_replica_count       | The number of replicas              |    1    |    ✕     |

--- a/k8s/redis/release.yaml
+++ b/k8s/redis/release.yaml
@@ -18,17 +18,10 @@ spec:
   # https://github.com/bitnami/charts/blob/main/bitnami/redis/values.yaml
   values:
     auth:
-      password: ${redis_password}
+      password: ${redis_password:=redis}
     master:
       persistence:
         enabled: ${redis_persistence_enabled:=false}
-      resources:
-        requests:
-          cpu: ${redis_master_cpu_request:=50m}
-          memory: ${redis_master_memory_request:=128Mi}
-        limits:
-          cpu: ${redis_master_cpu_limit:=100m}
-          memory: ${redis_master_memory_limit:=256Mi}
     replica:
       persistence:
         enabled: ${redis_persistence_enabled:=false}

--- a/k8s/testkube/README.md
+++ b/k8s/testkube/README.md
@@ -4,3 +4,10 @@ TestKube is a service that allows you to run tests on your Kubernetes cluster.
 
 - [Documentation](https://docs.testkube.io)
 - [Helm Chart](https://github.com/kubeshop/helm-charts/tree/develop/charts/testkube)
+
+## Post-build variables
+
+| Variable             | Description               | Default | Required |
+| -------------------- | ------------------------- | :-----: | :------: |
+| cluster_domain       | The domain of the cluster |   ""    |    ✓     |
+| cluster_ingress_port | The port of the ingress   |   ""    |    ✕     |

--- a/k8s/traefik/README.md
+++ b/k8s/traefik/README.md
@@ -14,11 +14,8 @@ Traefik is a reverse proxy and load balancer that routes incoming requests to th
 
 ## Post-build variables
 
-| Variable                         | Description                            | Default |
-| -------------------------------- | -------------------------------------- | :-----: |
-| traefik_ingress_load_balancer_ip | The IP address of the load balancer    |   ""    |
-| cluster_domain                   | The domain of the cluster              |   ""    |
-| traefik_cpu_request              | The CPU request for the Traefik pod    |  100m   |
-| traefik_memory_request           | The memory request for the Traefik pod |  50Mi   |
-| traefik_cpu_limit                | The CPU limit for the Traefik pod      |  200m   |
-| traefik_memory_limit             | The memory limit for the Traefik pod   |  100Mi  |
+| Variable                         | Description                                                       |   Default    | Required |
+| -------------------------------- | ----------------------------------------------------------------- | :----------: | :------: |
+| cluster_domain                   | The domain of the cluster                                         |      ""      |    ✓     |
+| traefik_ingress_load_balancer_ip | The IP address of the load balancer                               |      ""      |    ✕     |
+| traefik_service_type             | The service to provide ingressing for (LoadBalancer or ClusterIP) | LoadBalancer |    ✕     |

--- a/k8s/traefik/release.yaml
+++ b/k8s/traefik/release.yaml
@@ -36,10 +36,3 @@ spec:
         matchRule: Host(`traefik.${cluster_domain}`)
         entryPoints:
           - websecure
-    resources:
-      requests:
-        cpu: ${traefik_cpu_request:=100m}
-        memory: ${traefik_memory_request:=50Mi}
-      limits:
-        cpu: ${traefik_cpu_limit:=200m}
-        memory: ${traefik_memory_limit:=100Mi}


### PR DESCRIPTION
This PR does some clean up in preparation for the Vertical Pod Autoscaler deployment.

- Updates all post-build variables in README´s to correctly reflect the options.
- Removes all resource requests and limits.

Closes #37 