### PR TITLE
Add Vertical Pod Scaler and Metrics Server to OCI Artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,19 @@
 > [!WARNING]
 > This repo is temporarily public, as Kustomize does not support pulling from OCI yet. See [#4](https://github.com/energinet-digitalisering/oci-artifacts/issues/4)
 
-
 This repository contains Kubernetes (K8s) manifests distributed as OCI Artifacts.
 
 - [Cert Manager](k8s/cert-manager/README.md)
+- [GitHub Actions Runner Scale Set](k8s/gha-runner-scale-set/README.md)
+- [GitHub Actions Runner Scale Set Controller](k8s/gha-runner-scale-set-controller/README.md)
 - [Harbor](k8s/harbor/README.md)
+- [Metrics Server](k8s/metrics-server/README.md)
 - [Pulumi Operator](k8s/pulumi-operator/README.md)
 - [Redis](k8s/redis/README.md)
 - [Reloader](k8s/reloader/README.md)
 - [Testkube](k8s/testkube/README.md)
 - [Traefik](k8s/traefik/README.md)
+- [Vertical Pod Autoscaler](k8s/vertical-pod-autoscaler/README.md)
 
 OCI Artifacts are a great way to distribute ready-to-use K8s manifests. It requires almost no lines of code to get services deployed, so it can in some cases be a great alternative to Helm charts. However it does not have the same innate flexibility as Helm charts, so it is not a replacement for Helm charts. So the main reason to use OCI Artifacts is to get a service deployed with as little effort as possible. It might not work for advanced use-cases, but for simple (most) use-cases it will make your life easier.
 

--- a/k8s/metrics-server/README.md
+++ b/k8s/metrics-server/README.md
@@ -1,0 +1,4 @@
+# Metrics Server
+
+Metrics Server is a scalable, efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines.
+

--- a/k8s/metrics-server/kustomization.yaml
+++ b/k8s/metrics-server/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metrics-server
+resources:
+  - namespace.yaml
+  - release.yaml
+  - repository.yaml

--- a/k8s/metrics-server/namespace.yaml
+++ b/k8s/metrics-server/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metrics-server

--- a/k8s/metrics-server/release.yaml
+++ b/k8s/metrics-server/release.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: metrics-server
+spec:
+  interval: 5m
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  chart:
+    spec:
+      chart: metrics-server
+      version: 3.12.0
+      sourceRef:
+        kind: HelmRepository
+        name: metrics-server
+  # https://github.com/kubernetes-sigs/metrics-server/blob/master/charts/metrics-server/values.yaml
+  values: {}

--- a/k8s/metrics-server/repository.yaml
+++ b/k8s/metrics-server/repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: metrics-server
+spec:
+  interval: 5m
+  url: https://kubernetes-sigs.github.io/metrics-server/

--- a/k8s/vertical-pod-autoscaler/README.md
+++ b/k8s/vertical-pod-autoscaler/README.md
@@ -1,0 +1,23 @@
+# Vertical Pod Autoscaler
+
+A service that automatically adjusts the CPU and memory reservations for your pods to help them run more efficiently.
+
+## Dependencies
+
+- [Metrics Server](../infrastructure/metrics-server/README.md)
+
+## CRDs
+
+### VerticalPodAutoscaler
+
+```yaml
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: <vpa-name>
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: <Deployment | StatefulSet | DaemonSet>
+    name: <target-name>
+```

--- a/k8s/vertical-pod-autoscaler/kustomization.yaml
+++ b/k8s/vertical-pod-autoscaler/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: vertical-pod-autoscaler
+resources:
+  - namespace.yaml
+  - release.yaml
+  - repository.yaml

--- a/k8s/vertical-pod-autoscaler/namespace.yaml
+++ b/k8s/vertical-pod-autoscaler/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vertical-pod-autoscaler

--- a/k8s/vertical-pod-autoscaler/release.yaml
+++ b/k8s/vertical-pod-autoscaler/release.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: vertical-pod-autoscaler
+spec:
+  interval: 5m
+  dependsOn:
+    - name: metrics-server
+      namespace: metrics-server
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  chart:
+    spec:
+      chart: vertical-pod-autoscaler
+      version: 9.6.0
+      sourceRef:
+        kind: HelmRepository
+        name: vertical-pod-autoscaler
+  # https://github.com/cowboysysop/charts/blob/master/charts/vertical-pod-autoscaler/values.yaml
+  values: {}

--- a/k8s/vertical-pod-autoscaler/repository.yaml
+++ b/k8s/vertical-pod-autoscaler/repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: vertical-pod-autoscaler
+spec:
+  interval: 5m
+  url: https://cowboysysop.github.io/charts


### PR DESCRIPTION
This pull request adds the Vertical Pod Scaler and Metrics Server to the OCI Artifacts repository. The Vertical Pod Scaler is a service that automatically adjusts the CPU and memory reservations for pods to help them run more efficiently. The Metrics Server is a scalable, efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines. This update enhances the functionality and flexibility of the OCI Artifacts repository. 

Fixes #38
Closes https://github.com/energinet-digitalisering/substation-gateway-cluster/issues/46