### PR TITLE
Add Prometheus Operator CRDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains Kubernetes (K8s) manifests distributed as OCI Artifacts
 - [GitHub Actions Runner Scale Set Controller](k8s/gha-runner-scale-set-controller/README.md)
 - [Harbor](k8s/harbor/README.md)
 - [Metrics Server](k8s/metrics-server/README.md)
+- [Prometheus Operator CRDs](k8s/prometheus-operator-crds/README.md)
 - [Pulumi Operator](k8s/pulumi-operator/README.md)
 - [Redis](k8s/redis/README.md)
 - [Reloader](k8s/reloader/README.md)

--- a/k8s/clusters/oci-artifacts-ksail/infrastructure/services/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts-ksail/infrastructure/services/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../../../gha-runner-scale-set-controller
   - ../../../../harbor
   - ../../../../metrics-server
+  - ../../../../prometheus-operator-crds
   - ../../../../pulumi-operator
   - ../../../../redis
   - ../../../../reloader

--- a/k8s/prometheus-operator-crds/README.md
+++ b/k8s/prometheus-operator-crds/README.md
@@ -1,0 +1,5 @@
+# Prometheus Operator CRDs
+
+The OTEL Collector uses the Prometheus Operator CRDs to discover Prometheus scrape targets.
+
+- [Documentation and Helm Chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-operator-crds)

--- a/k8s/prometheus-operator-crds/kustomization.yaml
+++ b/k8s/prometheus-operator-crds/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: prometheus-operator-crds
+resources:
+  - namespace.yaml
+  - release.yaml
+  - repository.yaml

--- a/k8s/prometheus-operator-crds/namespace.yaml
+++ b/k8s/prometheus-operator-crds/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prometheus-operator-crds

--- a/k8s/prometheus-operator-crds/release.yaml
+++ b/k8s/prometheus-operator-crds/release.yaml
@@ -15,5 +15,5 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: prometheus-operator-crds
-  # https://github.com/stakater/Reloader/blob/master/deployments/kubernetes/chart/reloader/values.yaml
+  # https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-operator-crds/values.yaml
   values: {}

--- a/k8s/prometheus-operator-crds/release.yaml
+++ b/k8s/prometheus-operator-crds/release.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: prometheus-operator-crds
+spec:
+  interval: 5m
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  chart:
+    spec:
+      chart: prometheus-operator-crds
+      version: 9.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-operator-crds
+  # https://github.com/stakater/Reloader/blob/master/deployments/kubernetes/chart/reloader/values.yaml
+  values: {}

--- a/k8s/prometheus-operator-crds/repository.yaml
+++ b/k8s/prometheus-operator-crds/repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: prometheus-operator-crds
+spec:
+  interval: 5m
+  url: https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
## Description

This adds the required Custom Resource Definitions `PodMonitor` and `ServiceMonitor` by installing the prometheus-operator-crds Helm release.

This Helm release also includes other CRDs, which are not used currently. An alternative would be to install the yaml files directly:
- https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
- https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml

 However, I assume it will be easier to maintain the installation of the Helm chart rather than individual yaml files. Please let me know if that is false 😄 

Closes #50 
