### PR TITLE
Add otel operator

### DIFF
--- a/k8s/clusters/oci-artifacts-ksail/infrastructure/configs/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts-ksail/infrastructure/configs/kustomization.yaml
@@ -3,4 +3,6 @@ kind: Kustomization
 resources:
   - ../../../../cert-manager/certificates/cluster-issuer-certificate.yaml
   - ../../../../cert-manager/cluster-issuers/selfsigned-cluster-issuer.yaml
+  - ../../../../otel-operator/collectors/otel-collector-cluster.yaml
+  - ../../../../otel-operator/collectors/otel-collector-node.yaml
   - ../../../../testkube/executors/dotnet-container-executor.yaml

--- a/k8s/clusters/oci-artifacts-ksail/infrastructure/services/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts-ksail/infrastructure/services/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../../../gha-runner-scale-set-controller
   - ../../../../harbor
   - ../../../../metrics-server
+  - ../../../../otel-operator
   - ../../../../prometheus-operator-crds
   - ../../../../pulumi-operator
   - ../../../../redis

--- a/k8s/otel-operator/README.md
+++ b/k8s/otel-operator/README.md
@@ -1,0 +1,41 @@
+# OpenTelemetry Operator
+
+The OTEL Operator offers a vendor-agnostic implementation of a ControlPlane to create and manage OTEL related resources.
+
+- [Documentation](https://opentelemetry.io/docs/kubernetes/helm/operator/)
+- [Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-operator)
+
+## Preset Collectors
+
+This OCI Artifact includes a set preconfigured collectors to make it easier to get started with telemetry collection.
+
+These are configured to match the default preset configuration described in the [OTEL Collector's Getting Started guide for Kubernetes](https://opentelemetry.io/docs/kubernetes/getting-started/).
+
+By default these presets do not include exporters, and will only export telemetry to standard out. For more advanced use cases, these OCI artifacts can be used as templates, or be patched with Kustomize.
+
+> [!NOTE]
+> In the future these collectors might be expanded to support exporting to popular backends.
+
+### Kubernetes Cluster Telemetry
+
+This collector is configured to receive cluster-wide metrics and events from a Kubernetes cluster. It runs a single replica in the cluster to avoid creating duplicates.
+
+It has the following receivers configured:
+
+- [Kubernetes Cluster Receiver](https://opentelemetry.io/docs/kubernetes/collector/components/#kubernetes-cluster-receiver)
+- [Kubernetes Objects Receiver](https://opentelemetry.io/docs/kubernetes/collector/components/#kubernetes-objects-receiver)
+- Prometheus - to scrape metrics from the OTEL Collector itself.
+
+### Kubernetes Node Telemetry
+
+This collector is configured to receive telemetry from all nodes. It runs as a DaemonSet, defaulting to one agent per node. It receives/scrapes on the following:
+
+- Kubelet Stats (port 10250) - node, pod, container, and volume metrics from the KAPI server
+- OTLP (port 4317/grpc and 4318/http) - Application telemetry and instrumentation
+- Prometheus (port 8888) - the OTEL Collectors own metrics (its a list that can be expanded to scrape more targets)
+
+To learn more about the different recievers visit the following links:
+
+- [Kubelet Stats Receiver](https://opentelemetry.io/docs/kubernetes/collector/components/##kubeletstats-receiver)
+- [OTLP Receiver](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md)
+- [Prometheus Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/README.md)

--- a/k8s/otel-operator/collectors/otel-collector-cluster.yaml
+++ b/k8s/otel-operator/collectors/otel-collector-cluster.yaml
@@ -1,0 +1,160 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector-cluster
+  namespace: otel-operator
+  labels:
+    app: otel-collector-cluster
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-collector-cluster
+  namespace: otel-operator
+  labels:
+    app: otel-collector-cluster
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - events
+      - namespaces
+      - namespaces/status
+      - nodes
+      - nodes/spec
+      - pods
+      - pods/status
+      - replicationcontrollers
+      - replicationcontrollers/status
+      - resourcequotas
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-collector-cluster
+  namespace: otel-operator
+  labels:
+    app: otel-collector-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otel-collector-cluster
+subjects:
+- kind: ServiceAccount
+  name: otel-collector-cluster
+  namespace: otel-operator
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-collector-cluster
+  namespace: otel-operator
+spec:
+  mode: deployment
+  replicas: 1
+  serviceAccount: otel-collector-cluster
+  env:
+    - name: MY_POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+  config: |
+    receivers:
+      k8s_cluster:
+        auth_type: serviceAccount
+        collection_interval: 10s
+      k8sobjects:
+        auth_type: serviceAccount
+        objects:
+          - name: events
+            mode: watch
+            group: events.k8s.io
+            exclude_watch_type:
+              - DELETED
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: otel-collector-cluster
+            scrape_interval: 10s
+            static_configs:
+              - targets:
+                - $${env:MY_POD_IP}:8888
+    processors:
+      batch: {}
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+    exporters:
+      debug:
+        verbosity: detailed
+      logging: {}
+    service:
+      pipelines:
+        metrics:
+          receivers:
+            - k8s_cluster
+            - prometheus
+          processors:
+            - memory_limiter
+            - batch
+          exporters:
+            - debug
+        logs:
+          receivers:
+            - k8sobjects
+            - k8s_cluster
+          processors:
+            - memory_limiter
+            - batch
+          exporters:
+            - debug
+    extensions:
+      health_check:
+        endpoint: $${env:MY_POD_IP}:13133
+    telemetry:
+        metrics:
+          address: $${env:MY_POD_IP}:8888

--- a/k8s/otel-operator/collectors/otel-collector-node.yaml
+++ b/k8s/otel-operator/collectors/otel-collector-node.yaml
@@ -1,0 +1,157 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector-node
+  namespace: otel-operator
+  labels:
+    app: otel-collector-node
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-collector-node
+  namespace: otel-operator
+  labels:
+    app: otel-collector-node
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - 'pods'
+      - 'namespaces'
+      - 'nodes/stats'
+    verbs:
+      - 'get'
+      - 'watch'
+      - 'list'
+  - apiGroups:
+      - 'apps'
+    resources:
+      - 'replicasets'
+    verbs:
+      - 'get'
+      - 'list'
+      - 'watch'
+  - apiGroups:
+      - 'extensions'
+    resources:
+      - 'replicasets'
+    verbs:
+      - 'get'
+      - 'list'
+      - 'watch'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-collector-node
+  namespace: otel-operator
+  labels:
+    app: otel-collector-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otel-collector-node
+subjects:
+  - kind: ServiceAccount
+    name: otel-collector-node
+    namespace: otel-operator
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-collector-node
+  namespace: otel-operator
+spec:
+  mode: daemonset
+  serviceAccount: otel-collector-node
+  env:
+    - name: MY_POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+  config: |
+    receivers:
+      kubeletstats:
+        auth_type: serviceAccount
+        collection_interval: 20s
+        endpoint: $${env:K8S_NODE_NAME}:10250
+      otlp:
+        protocols:
+          grpc:
+            endpoint: $${env:MY_POD_IP}:4317
+          http:
+            endpoint: $${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: otel-collector-node
+              scrape_interval: 10s
+              static_configs:
+              - targets:
+                - $${env:MY_POD_IP}:8888
+    processors:
+      batch: {}
+      k8sattributes:
+        extract:
+          metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.pod.start_time
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+    exporters:
+      debug:
+        verbosity: detailed
+      logging: {}
+    service:
+      pipelines:
+        logs:
+          receivers:
+            - otlp
+          processors:
+            - k8sattributes
+            - memory_limiter
+            - batch
+          exporters:
+            - debug
+        metrics:
+          receivers:
+            - otlp
+            - kubeletstats
+            - prometheus
+          processors:
+            - k8sattributes
+            - memory_limiter
+            - batch
+          exporters:
+            - debug
+    telemetry:
+      metrics:
+        address: $${env:MY_POD_IP}:8888

--- a/k8s/otel-operator/kustomization.yaml
+++ b/k8s/otel-operator/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: otel-operator
+resources:
+  - namespace.yaml
+  - release.yaml
+  - repository.yaml

--- a/k8s/otel-operator/namespace.yaml
+++ b/k8s/otel-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: otel-operator

--- a/k8s/otel-operator/release.yaml
+++ b/k8s/otel-operator/release.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: otel-operator
+spec:
+  interval: 5m
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  chart:
+    spec:
+      chart: opentelemetry-operator
+      version: 0.48.0
+      sourceRef:
+        kind: HelmRepository
+        name: otel-operator
+  # https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/values.yaml
+  values: {}

--- a/k8s/otel-operator/repository.yaml
+++ b/k8s/otel-operator/repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: otel-operator
+spec:
+  interval: 5m
+  url: https://open-telemetry.github.io/opentelemetry-helm-charts


### PR DESCRIPTION
## Description

This PR adds manifest files for the OTEL Operator Helm chart along with two optional manifests for default k8s monitoring with the OTEL collector.

Closes https://github.com/energinet-digitalisering/oci-artifacts/issues/51
