### PR TITLE
Add otel-collector-k8s

### DIFF
--- a/k8s/clusters/oci-artifacts-ksail/infrastructure/services/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts-ksail/infrastructure/services/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../../../gha-runner-scale-set-controller
   - ../../../../harbor
   - ../../../../metrics-server
+  - ../../../../otel-collector-k8s
   - ../../../../otel-operator
   - ../../../../prometheus-operator-crds
   - ../../../../pulumi-operator

--- a/k8s/otel-collector-k8s/README.md
+++ b/k8s/otel-collector-k8s/README.md
@@ -1,0 +1,12 @@
+# OTEL Collector K8s
+
+The OpenTelemetry Collector offers a vendor-agnostic implementation of how to receive, process and export telemetry data. The OTEL Collector Helm chart provided by the OpenTelemetry project includes configuration presets for easily setting up OTEL Collectors that can collect telemetry from a Kubernetes cluster.
+
+This manifest packages the OTEL Collector Helm chart and installs two HelmReleases:
+
+1) `otel-collector-node` which runs an instance on every Kubernetes node. This collector collects pod logs and Kubelet metrics
+2) `otel-collector-cluster` which only has one instance. This collector collects cluster-level metrics and events.
+
+- [Getting Started](https://opentelemetry.io/docs/kubernetes/getting-started/)
+- [Documentation](https://opentelemetry.io/docs/kubernetes/helm/collector/)
+- [Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector)

--- a/k8s/otel-collector-k8s/kustomization.yaml
+++ b/k8s/otel-collector-k8s/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: otel-collector-k8s
+resources:
+  - namespace.yaml
+  - repository.yaml
+  - otel-collector-node.yaml
+  - otel-collector-cluster.yaml

--- a/k8s/otel-collector-k8s/namespace.yaml
+++ b/k8s/otel-collector-k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: otel-collector-k8s

--- a/k8s/otel-collector-k8s/otel-collector-cluster.yaml
+++ b/k8s/otel-collector-k8s/otel-collector-cluster.yaml
@@ -1,0 +1,26 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: otel-collector-cluster
+spec:
+  interval: 5m
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  chart:
+    spec:
+      chart: opentelemetry-collector
+      version: 0.82.0
+      sourceRef:
+        kind: HelmRepository
+        name: otel-collector
+  # https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/values.yaml
+  values:
+    mode: deployment
+
+    presets:
+      clusterMetrics:
+        enabled: true
+      kubernetesEvents:
+        enabled: true

--- a/k8s/otel-collector-k8s/otel-collector-node.yaml
+++ b/k8s/otel-collector-k8s/otel-collector-node.yaml
@@ -1,0 +1,28 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: otel-collector-node
+spec:
+  interval: 5m
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  chart:
+    spec:
+      chart: opentelemetry-collector
+      version: 0.82.0
+      sourceRef:
+        kind: HelmRepository
+        name: otel-collector
+  # https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/values.yaml
+  values:
+    mode: daemonset
+
+    presets:
+      kubernetesAttributes:
+        enabled: true
+      kubeletMetrics:
+        enabled: true
+      logsCollection:
+        enabled: true

--- a/k8s/otel-collector-k8s/repository.yaml
+++ b/k8s/otel-collector-k8s/repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: otel-collector
+spec:
+  interval: 5m
+  url: https://open-telemetry.github.io/opentelemetry-helm-charts


### PR DESCRIPTION
## Description

This PR adds manifests for the OTEL Collector helm chart which have been preconfigured for K8s monitoring using the official presets. This is very similar to what was introduced in #66, but by using the official presets it is much less work for us to maintain. 